### PR TITLE
Fix edu domain detection mechanism 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+dnspython
+idna
+pypinyin
+requests
+tldextract

--- a/verify-url.py
+++ b/verify-url.py
@@ -16,6 +16,7 @@ import sys
 import threading
 import traceback
 import warnings
+import tldextract
 
 
 print_lock = threading.Lock()
@@ -213,8 +214,14 @@ def get_domain(url):
 
 
 def check_whitelist(url):
-    for i in whitelist:
-        if re.search(i, url):
+    extracted = tldextract.extract(url)
+    domain = f"{extracted.domain}.{extracted.suffix}"
+    
+    for pattern in whitelist:
+        if pattern == "edu":
+            if extracted.suffix == "edu":
+                return True
+        elif re.search(pattern, domain):
             return True
     return False
 


### PR DESCRIPTION
# 提高教育类域名识别的准确性

## 描述
这个PR旨在提高脚本中教育类域名识别的准确性，并更新项目依赖。当前的实现可能会导致误报，例如将"genshinedu.com"错误地识别为教育类域名。通过使用`tldextract`库，我们可以更精确地解析URL并正确识别真正的`.edu`域名。

## 变更内容
1. 引入`tldextract`库来解析URL。
2. 修改`check_whitelist`函数，使用`tldextract`来准确提取域名组件。
3. 更新了对"edu"域名的检查逻辑，现在只有真正的`.edu`顶级域名才会被识别为教育类域名。
4. 保持了对白名单中其他模式的支持。

## 额外说明
这个更改提高了域名识别的准确性，同时保持了对现有白名单规则的兼容性。同时，我们更新了`requirements.txt`文件以确保所有必要的依赖都能被正确安装。