### PR TITLE
补充问卷中尚未收录的学校域名

### DIFF
--- a/new/survey-20260719.add.md
+++ b/new/survey-20260719.add.md
@@ -1,0 +1,10 @@
+| [山东原神中学.icu](https://山东原神中学.icu/) | 山东省滕州市第一中学 |
+| [道外区原神大学.cn](https://道外区原神大学.cn) | 黑龙江工程学院 |
+| [博士多托雷研究学院.senwoo.fun](http://博士多托雷研究学院.senwoo.fun) | 云原神大学 |
+| [原神小学.com](https://原神小学.com) | 通川区第一小学校 |
+| [中国原神大学.online](https://www.中国原神大学.online) | 中国社会科学院大学 |
+| [黑龙江原神大学.icu](http://黑龙江原神大学.icu) | 佳木斯大学 |
+| [哈尔滨原神大学.cn](https://www.哈尔滨原神大学.cn) | 哈尔滨理工大学 |
+| [加拿大原神大学.com](http://加拿大原神大学.com) | Simon Fraser University |
+| [guc.edu.kg](https://www.guc.edu.kg/) | 中国原神大学 |
+| [原神中学.02.gold](http://原神中学.02.gold/) | 江苏省响水中学 |


### PR DESCRIPTION
## 说明

- 对比 2026-07-19 问卷 CSV 与 README 中现有 277 条记录。
- 新增 10 个尚未收录、且当前可访问或可跳转的域名。
- 对问卷中带有无效 www 前缀或仅 HTTP 可用的链接采用实测可访问地址。
- 未纳入 NXDOMAIN、HTTP 404、直链学校/百度页面及拼写错误的重复项。

## 校验

- 10 行均符合 new/README.md 规定的 .add.md 格式。
- 新增域名在当前 README 中均无重复。
- 文件为 UTF-8（无 BOM），git diff --check 通过。