### PR TITLE
补齐最新问卷中的遗漏学校域名

### DIFF
--- a/new/survey-reconciliation-20260801.add.md
+++ b/new/survey-reconciliation-20260801.add.md
@@ -1,0 +1,9 @@
+| [原神音乐学院.icu](https://原神音乐学院.icu) | 星海音乐学院 |
+| [湖北原神大学.baby](http://湖北原神大学.baby) | 湖北文理学院 |
+| [湖南原神职业技术学院.com](https://www.湖南原神职业技术学院.com) | 湖南城建职业技术学院 |
+| [genshin-birmingham.uk](http://genshin-birmingham.uk/) | University of Birmingham |
+| [伯明翰大学原神学院.top](http://伯明翰大学原神学院.top/) | University of Birmingham |
+| [齐鲁原神大学.com](https://www.齐鲁原神大学.com) | 齐鲁工业大学 |
+| [ugenshin.ca](http://ugenshin.ca) | University of Toronto |
+| [原神舱.cn](https://原神舱.cn) | 实验舱 |
+| [原神工作室.com](https://原神工作室.com) | 小码王立方工作室 |


### PR DESCRIPTION
## 变更说明

完整解析 2026-08-01 导出的问卷 CSV（98 条记录），并与当前 README 的 293 条记录进行域名归一化比对。本次补充 9 个具有明确完整域名、但尚未收录的条目：

- 原神音乐学院.icu — 星海音乐学院
- 湖北原神大学.baby — 湖北文理学院
- 湖南原神职业技术学院.com — 湖南城建职业技术学院
- genshin-birmingham.uk — University of Birmingham
- 伯明翰大学原神学院.top — University of Birmingham
- 齐鲁原神大学.com — 齐鲁工业大学
- ugenshin.ca — University of Toronto
- 原神舱.cn — 实验舱
- 原神工作室.com — 小码王立方工作室

未加入无法确定域名后缀的两条记录，以及一条已收录域名的错别字重复记录；问卷第 100 条也已在现有名单中，因此未重复添加。

## 校验

- 9 行均符合 `new/README.md` 规定的 `.add.md` 格式。
- 新增域名在当前 README 中无重复。
- 文件为 UTF-8（无 BOM），`git diff --check` 通过。
- `湖北原神大学.baby` 当前可正常跳转到湖北文理学院官网；其余域名目前为 NXDOMAIN 或 HTTP 404，自动刷新流程会按实际状态标记并持续复检。