### PR TITLE
Correct Heilongjiang University association

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@
 | [广州原神大学.icu](https://广州原神大学.icu) | 广州南洋理工职业学院 | :x: NXDOMAIN |
 | [原神启动.space](https://www.原神启动.space) | 广州商学院 | :x: NXDOMAIN |
 | [原神理工大学.icu](http://www.原神理工大学.icu) | 桂林理工大学南宁分校 | :x: NXDOMAIN |
-| [黑龙江原神大学.com](http://www.黑龙江原神大学.com) | 哈尔滨工程大学 | :white_check_mark: Redirect 301 |
+| [黑龙江原神大学.com](http://www.黑龙江原神大学.com) | 黑龙江大学 | :white_check_mark: Redirect 301 |
 | [哈尔滨原神大学.com](http://哈尔滨原神大学.com) | 哈尔滨工程大学 | :white_check_mark: Redirect 308 |
 | [提瓦特工业大学.com](http://提瓦特工业大学.com) | 哈尔滨工业大学 | :white_check_mark: Redirect 301 |
 | [东北原神大学.top](https://www.东北原神大学.top) | 哈尔滨理工大学 | :white_check_mark:  |


### PR DESCRIPTION
## What changed

Updated the `黑龙江原神大学.com` entry from 哈尔滨工程大学 to 黑龙江大学.

## Why

The domain entered a new registration lifecycle on 2026-08-01 and now permanently redirects to the official Heilongjiang University website. The previous school label was historical data that remained unchanged when the automated status checker changed the domain status from NXDOMAIN to Redirect 301.

## Impact

The university association now matches both the current redirect target and the latest questionnaire submission.

## Validation

- Confirmed the README contains exactly one matching entry associated with 黑龙江大学.
- Confirmed the domain returns HTTP 301 with `Location: https://www.hlju.edu.cn/`.
- Ran `git diff --check` successfully.