### PR TITLE
Run status update once daily

### DIFF
--- a/.github/workflows/update_status.yml
+++ b/.github/workflows/update_status.yml
@@ -15,7 +15,7 @@ on:
         type: 'boolean'
         default: false
   schedule:
-    - cron: '30 3/4 * * *'
+    - cron: '30 3 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
## What changed

Changed the `Update Status` workflow schedule from every four hours to once per day.

- Previous: `30 3/4 * * *` (six scheduled runs per day)
- New: `30 3 * * *` (03:30 UTC / 11:30 Asia/Shanghai)

## Why

The every-four-hours schedule creates six automated README status commits per day. The intended cadence is one daily status refresh.

## Impact

Scheduled status checks and their generated commits will be reduced from six per day to one per day after this PR is merged. Manual dispatch and qualifying pushes to `main` remain unchanged.

## Validation

- Parsed the workflow successfully with Psych/YAML.
- Ran `git diff --check` successfully.
- Confirmed the active cron expression is exactly `30 3 * * *`.