### PR TITLE
优先展示有效域名

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 非高校也可添加哟~
 
 喜欢本项目的话可以在[GitHub](https://github.com/cokice/List-of-genshin-University)内点个star。
-**该名单由学校名称字母顺序排列**
+**该名单优先展示有效域名，同一有效性分组内按学校名称字母顺序排列**
 
 ## 如何提交
 :::caution

--- a/verify-url.py
+++ b/verify-url.py
@@ -352,9 +352,16 @@ def reshape_pinyin(l):
     return o
 
 
+VALID_STATUS_MARKERS = (":white_check_mark:", ":question:")
+
+
 def sort_key(s):
-    m = re.match(r"\| *\[(.*?)\]\((?P<link>.*?)\) *\| *(?P<name>.*?) *\|.*", s)
+    m = re.match(
+        r"\| *\[(.*?)\]\((?P<link>.*?)\) *\| *(?P<name>.*?) *\| *(?P<status>.*?) *\|",
+        s,
+    )
     return [
+        0 if any(marker in m["status"] for marker in VALID_STATUS_MARKERS) else 1,
         reshape_pinyin(pypinyin.pinyin(m["name"], style="tone_with_original", errors=handle_no_pinyin)),
         reshape_pinyin(pypinyin.pinyin(m["link"], style="tone_with_original", errors=handle_no_pinyin)),
     ]


### PR DESCRIPTION
## 修改内容

- 将 `:white_check_mark:` 和 `:question:` 归入有效状态分组并优先展示。
- 同一有效性分组内继续按学校名称拼音排序，链接作为最终兜底键。
- 更新 README 中的排序规则说明。

## 原因

当前列表只按学校名称排序，仍可访问的域名容易淹没在大量失效记录中。本次调整实现 Issue #230 提出的“有效状态优先、名称其次”排序，同时保持组内顺序稳定。

## 影响

合并后，下一次 `Update Status` 工作流会将有效域名集中排列在列表前部。`:white_check_mark:` 与 `:question:` 之间的变化不会触发跨组移动，只有有效与无效状态发生变化时记录才会换组。

## 验证

- 使用四种状态的样例验证有效状态、中文校名和链接兜底排序。
- 使用当前 README 的全部 304 条记录验证：80 条有效记录正确置顶，排序结果具备幂等性。
- Python 语法检查通过。
- `git diff --check` 通过。
- 修改文件均为 UTF-8（无 BOM）。

Closes #230